### PR TITLE
Disable quick pulldown by default

### DIFF
--- a/overlay/common/vendor/cmsdk/packages/CMSettingsProvider/res/values/defaults.xml
+++ b/overlay/common/vendor/cmsdk/packages/CMSettingsProvider/res/values/defaults.xml
@@ -15,14 +15,6 @@
      limitations under the License.
 -->
 <resources>
-    <!-- Defaults for System -->
-
-    <!-- Default for CMSettings.System.QS_QUICK_PULLDOWN
-         0. Off
-         1. Right
-         2. Left -->
-    <integer name="def_qs_quick_pulldown">1</integer>
-
     <!-- Defaults for Secure -->
 
     <!-- Default for CMSettings.Secure.STATS_COLLECTION -->


### PR DESCRIPTION
With Android N this feature became less relevant since a subset of
the toggles is available without fully expanding the notification
panel. This gives better access to the notifications with almost no
functionality loss.

Change-Id: Idb66472b77e60f4ae753c5dd00f6588566cc3c63