### PR TITLE
extract-utils: Fix handling of pulling src:dest pairs from dumps

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -853,12 +853,12 @@ function extract() {
                 adb pull "/$FILE" "$DEST"
             fi
         else
-            # Try OEM target first
-            if [ -f "$SRC/$FILE" ]; then
-                cp "$SRC/$FILE" "$DEST"
-            # if file does not exist try CM target
-            elif [ -f "$SRC/$TARGET" ]; then
+            # Try CM target first
+            if [ -f "$SRC/$TARGET" ]; then
                 cp "$SRC/$TARGET" "$DEST"
+            # if file does not exist try OEM target
+            elif [ -f "$SRC/$FILE" ]; then
+                cp "$SRC/$FILE" "$DEST"
             else
                 printf '    !! file not found in source\n'
             fi


### PR DESCRIPTION
Currently, the priority of the src and dest is inverted between
pulling from adb and pulling from a system dump.

Assume that we have a camera wrapper and write the proprietary-files.txt

lib/hw/camera.msm8996.so:lib/hw/camera.vendor.msm8996.so

If we pull from a phone running Lineage that has both files, we get

camera.vendor.msm8996.so

as the pulled blob.  If we take the exact same build and pull it
from the system dump (aka, your own $OUT directory that built the
installed software) you get

camera.msm8996.so

pull instead!

Make both paths follow the same logic so that you get the same
file independent of the source.

Change-Id: I479e0ae765339cc38fa05fcaad7943c528129463