### PR TITLE
Add TvSettings to common tv config.

### DIFF
--- a/config/common_full_tv.mk
+++ b/config/common_full_tv.mk
@@ -1,2 +1,4 @@
 # Inherit common CM stuff
 $(call inherit-product, vendor/cm/config/common_full.mk)
+
+PRODUCT_PACKAGES += TvSettings


### PR DESCRIPTION
This is required for all ATV builds. SUW will crash looking up the
wifi activity is it isn't installed.

Change-Id: Iccc982f46963024c065ac0b7c578ad60eb4d7d7a