### PR TITLE
cm: allow apps to find profile manager service

### DIFF
--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,2 +1,3 @@
 allow untrusted_app cm_weather_service:service_manager find;
 allow untrusted_app cm_status_bar_service:service_manager find;
+allow untrusted_app cm_profile_service:service_manager find;


### PR DESCRIPTION
avc:  denied  { find } for service=profile pid=7970 uid=10086 scontext=u:r:untrusted_app:s0:c512,c768
    tcontext=u:object_r:cm_profile_service:s0 tclass=service_manager permissive=1
java.lang.RuntimeException: Unable to start activity ComponentInfo{foo.bar/foo.bar.Activity}: java.lang.SecurityException:
    You do not have permissions to change the Profile Manager.: Neither user 10086 nor current process has cyanogenmod.permission.MODIFY_PROFILES.

Ticket: BUGBASH-174

Change-Id: If8706177bf6eef8d5e4c73da4f00cc053987d1ed
Signed-off-by: Joey Rizzoli <joey@lineageos.org>