### PR TITLE
roomservice: handle devices with underscores

### DIFF
--- a/build/tools/roomservice.py
+++ b/build/tools/roomservice.py
@@ -255,7 +255,7 @@ if depsonly:
 else:
     for repository in repositories:
         repo_name = repository['name']
-        if repo_name.startswith("android_device_") and repo_name.endswith("_" + device):
+        if re.match(r"^android_device_[^_]*_" + device + "$", repo_name):
             print("Found repository: %s" % repository['name'])
             
             manufacturer = repo_name.replace("android_device_", "").replace("_" + device, "")


### PR DESCRIPTION
This change correctly handles devices with underscores in their
name even if there is a device with the same name after the last
underscore (spyder, umts_spyder) by not allowing any underscores
in the manufacturers name.

Without this change, spyder gets resolved to:
device/motorola_umts/spyder
device/motorola/spyder

Only the last one is valid.

With this change, both spyder and umts_spyder get resolved correctly.

Change-Id: I0c95ff126d827a2d6b58875dfcb9327e999f4913