### PR TITLE
fix check_blacklist function to work on wiped /system partition

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -42,10 +42,11 @@ return 1
 }
 
 check_blacklist() {
-  if [ -f /system/addon.d/blacklist ];then
+  if [ -f /system/addon.d/blacklist -a -d /$1/addon.d/ ]; then
       ## Discard any known bad backup scripts
       cd /$1/addon.d/
       for f in *sh; do
+          [ -f $f ] || continue
           s=$(md5sum $f | cut -c-32)
           grep -q $s /system/addon.d/blacklist && rm -f $f
       done


### PR DESCRIPTION
If /system is empty, /tmp/addon.d/ will not exist, "*sh" won't be
expanded, md5sum will not generate any output and the variable $s
will be empty. Therefore grep, which will receive only one arg, will
start to read the standard input and never exit, causing the
installation to never end. Fix this checking whether we have files
to read or not.

Change-Id: I656eab42e54b3f81da8c5ac81374b9deddcf8484